### PR TITLE
feat: add exact email monitoring as a monitor target type

### DIFF
--- a/app/api/monitoring/monitors/[id]/route.ts
+++ b/app/api/monitoring/monitors/[id]/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server"
 import { validateRequest, requireAdminRole } from "@/lib/auth"
-import { getMonitor, updateMonitor, deleteMonitor } from "@/lib/domain-monitor"
+import { getMonitor, updateMonitor, deleteMonitor, validateMonitorEntries } from "@/lib/domain-monitor"
 
 export const dynamic = 'force-dynamic'
 
@@ -67,16 +67,37 @@ export async function PUT(
     const updates: any = {}
 
     if (body.name !== undefined) updates.name = body.name.trim()
-    if (body.domains !== undefined) {
-      if (!Array.isArray(body.domains) || body.domains.length === 0) {
+
+    // Effective target type: the new one if provided, otherwise the existing one
+    let targetType: 'domain' | 'email' = existing.target_type
+    if (body.target_type !== undefined) {
+      if (!["domain", "email"].includes(body.target_type)) {
         return NextResponse.json(
-          { success: false, error: "At least one domain is required" },
+          { success: false, error: "target_type must be 'domain' or 'email'" },
           { status: 400 }
         )
       }
-      updates.domains = body.domains.map((d: string) => d.trim().toLowerCase())
+      targetType = body.target_type
+      updates.target_type = body.target_type
     }
-    if (body.match_mode !== undefined) {
+
+    if (body.domains !== undefined) {
+      if (!Array.isArray(body.domains) || body.domains.length === 0) {
+        return NextResponse.json(
+          { success: false, error: "At least one domain or email is required" },
+          { status: 400 }
+        )
+      }
+      const normalizedEntries = body.domains.map((d: string) => d.trim().toLowerCase())
+      const entryError = validateMonitorEntries(targetType, normalizedEntries, false)
+      if (entryError) {
+        return NextResponse.json({ success: false, error: entryError }, { status: 400 })
+      }
+      updates.domains = normalizedEntries
+    }
+
+    // match_mode only applies to domain monitors; for email monitors it is forced to 'credential'
+    if (body.match_mode !== undefined && targetType === "domain") {
       if (!["credential", "url", "both"].includes(body.match_mode)) {
         return NextResponse.json(
           { success: false, error: "match_mode must be 'credential', 'url', or 'both'" },

--- a/app/api/monitoring/monitors/route.ts
+++ b/app/api/monitoring/monitors/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server"
 import { validateRequest, requireAdminRole } from "@/lib/auth"
-import { createMonitor, listMonitors } from "@/lib/domain-monitor"
+import { createMonitor, listMonitors, validateMonitorEntries } from "@/lib/domain-monitor"
 
 export const dynamic = 'force-dynamic'
 
@@ -47,7 +47,7 @@ export async function POST(request: NextRequest) {
 
   try {
     const body = await request.json()
-    const { name, domains, match_mode, webhook_ids } = body
+    const { name, domains, target_type, match_mode, webhook_ids } = body
 
     if (!name || typeof name !== "string" || name.trim().length === 0) {
       return NextResponse.json(
@@ -58,22 +58,38 @@ export async function POST(request: NextRequest) {
 
     if (!domains || !Array.isArray(domains) || domains.length === 0) {
       return NextResponse.json(
-        { success: false, error: "At least one domain is required" },
+        { success: false, error: "At least one domain or email is required" },
         { status: 400 }
       )
     }
 
-    if (!["credential", "url", "both"].includes(match_mode)) {
+    if (target_type !== undefined && !["domain", "email"].includes(target_type)) {
+      return NextResponse.json(
+        { success: false, error: "target_type must be 'domain' or 'email'" },
+        { status: 400 }
+      )
+    }
+    const targetType: 'domain' | 'email' = target_type === "email" ? "email" : "domain"
+
+    // match_mode only applies to domain monitors; email monitors always match on credential email
+    if (targetType === "domain" && !["credential", "url", "both"].includes(match_mode)) {
       return NextResponse.json(
         { success: false, error: "match_mode must be 'credential', 'url', or 'both'" },
         { status: 400 }
       )
     }
 
+    const normalizedEntries = domains.map((d: string) => d.trim().toLowerCase())
+    const entryError = validateMonitorEntries(targetType, normalizedEntries, true)
+    if (entryError) {
+      return NextResponse.json({ success: false, error: entryError }, { status: 400 })
+    }
+
     const monitorId = await createMonitor({
       name: name.trim(),
-      domains: domains.map((d: string) => d.trim().toLowerCase()),
-      match_mode,
+      domains: normalizedEntries,
+      target_type: targetType,
+      match_mode: targetType === "email" ? "credential" : match_mode,
       webhook_ids: webhook_ids || [],
       created_by: user ? parseInt(user.userId) : undefined,
     })

--- a/app/api/v1/monitoring/monitors/[id]/route.ts
+++ b/app/api/v1/monitoring/monitors/[id]/route.ts
@@ -8,7 +8,7 @@
 
 import { NextRequest, NextResponse } from "next/server"
 import { withApiKeyAuth, addRateLimitHeaders, logApiRequest } from "@/lib/api-key-auth"
-import { getMonitor, updateMonitor, deleteMonitor } from "@/lib/domain-monitor"
+import { getMonitor, updateMonitor, deleteMonitor, validateMonitorEntries } from "@/lib/domain-monitor"
 
 export const dynamic = 'force-dynamic'
 
@@ -107,16 +107,40 @@ export async function PUT(
     const updates: any = {}
 
     if (body.name !== undefined) updates.name = body.name.trim()
-    if (body.domains !== undefined) {
-      if (!Array.isArray(body.domains) || body.domains.length === 0) {
+
+    // Effective target type: the new one if provided, otherwise the existing one
+    let targetType: 'domain' | 'email' = existing.target_type
+    if (body.target_type !== undefined) {
+      if (!["domain", "email"].includes(body.target_type)) {
         return NextResponse.json(
-          { success: false, error: "At least one domain is required", code: "VALIDATION_ERROR" },
+          { success: false, error: "target_type must be 'domain' or 'email'", code: "VALIDATION_ERROR" },
           { status: 400 }
         )
       }
-      updates.domains = body.domains.map((d: string) => d.trim().toLowerCase())
+      targetType = body.target_type
+      updates.target_type = body.target_type
     }
-    if (body.match_mode !== undefined) {
+
+    if (body.domains !== undefined) {
+      if (!Array.isArray(body.domains) || body.domains.length === 0) {
+        return NextResponse.json(
+          { success: false, error: "At least one domain or email is required", code: "VALIDATION_ERROR" },
+          { status: 400 }
+        )
+      }
+      const normalizedEntries = body.domains.map((d: string) => d.trim().toLowerCase())
+      const entryError = validateMonitorEntries(targetType, normalizedEntries, false)
+      if (entryError) {
+        return NextResponse.json(
+          { success: false, error: entryError, code: "VALIDATION_ERROR" },
+          { status: 400 }
+        )
+      }
+      updates.domains = normalizedEntries
+    }
+
+    // match_mode only applies to domain monitors; for email monitors it is forced to 'credential'
+    if (body.match_mode !== undefined && targetType === "domain") {
       if (!["credential", "url", "both"].includes(body.match_mode)) {
         return NextResponse.json(
           { success: false, error: "match_mode must be 'credential', 'url', or 'both'", code: "VALIDATION_ERROR" },

--- a/app/api/v1/monitoring/monitors/route.ts
+++ b/app/api/v1/monitoring/monitors/route.ts
@@ -7,7 +7,7 @@
 
 import { NextRequest, NextResponse } from "next/server"
 import { withApiKeyAuth, addRateLimitHeaders, logApiRequest } from "@/lib/api-key-auth"
-import { listMonitors, createMonitor } from "@/lib/domain-monitor"
+import { listMonitors, createMonitor, validateMonitorEntries } from "@/lib/domain-monitor"
 
 export const dynamic = 'force-dynamic'
 
@@ -71,7 +71,7 @@ export async function POST(request: NextRequest) {
 
   try {
     const body = await request.json()
-    const { name, domains, match_mode, webhook_ids } = body
+    const { name, domains, target_type, match_mode, webhook_ids } = body
 
     // Validation
     if (!name || typeof name !== "string" || name.trim().length === 0) {
@@ -83,22 +83,41 @@ export async function POST(request: NextRequest) {
 
     if (!domains || !Array.isArray(domains) || domains.length === 0) {
       return NextResponse.json(
-        { success: false, error: "At least one domain is required", code: "VALIDATION_ERROR" },
+        { success: false, error: "At least one domain or email is required", code: "VALIDATION_ERROR" },
         { status: 400 }
       )
     }
 
-    if (!["credential", "url", "both"].includes(match_mode)) {
+    if (target_type !== undefined && !["domain", "email"].includes(target_type)) {
+      return NextResponse.json(
+        { success: false, error: "target_type must be 'domain' or 'email'", code: "VALIDATION_ERROR" },
+        { status: 400 }
+      )
+    }
+    const targetType: 'domain' | 'email' = target_type === "email" ? "email" : "domain"
+
+    // match_mode only applies to domain monitors; email monitors always match on credential email
+    if (targetType === "domain" && !["credential", "url", "both"].includes(match_mode)) {
       return NextResponse.json(
         { success: false, error: "match_mode must be 'credential', 'url', or 'both'", code: "VALIDATION_ERROR" },
         { status: 400 }
       )
     }
 
+    const normalizedEntries = domains.map((d: string) => d.trim().toLowerCase())
+    const entryError = validateMonitorEntries(targetType, normalizedEntries, true)
+    if (entryError) {
+      return NextResponse.json(
+        { success: false, error: entryError, code: "VALIDATION_ERROR" },
+        { status: 400 }
+      )
+    }
+
     const monitorId = await createMonitor({
       name: name.trim(),
-      domains: domains.map((d: string) => d.trim().toLowerCase()),
-      match_mode,
+      domains: normalizedEntries,
+      target_type: targetType,
+      match_mode: targetType === "email" ? "credential" : match_mode,
       webhook_ids: webhook_ids || [],
       created_by: parseInt(payload.userId),
     })

--- a/app/docs/page.tsx
+++ b/app/docs/page.tsx
@@ -1110,6 +1110,7 @@ export default function DocsPage() {
       "id": 1,
       "name": "Banking Domains",
       "domains": ["bank.co.id", "bca.co.id"],
+      "target_type": "domain",
       "match_mode": "both",
       "is_active": true,
       "webhook_count": 2,
@@ -1142,17 +1143,25 @@ export default function DocsPage() {
                   <h4 className="font-semibold mb-3 text-foreground">Request Body Parameters</h4>
                   <ParameterTable params={[
                     { name: "name", type: "string", required: true, description: "Monitor display name" },
-                    { name: "domains", type: "string[]", required: true, description: "Array of domains to monitor (min 1). Subdomains are matched automatically." },
-                    { name: "match_mode", type: "string", required: true, description: "Match mode: 'credential' (email only), 'url' (URL only), or 'both'" },
+                    { name: "target_type", type: "string", required: false, description: "'domain' (default) matches by domain/subdomain; 'email' matches exact email addresses" },
+                    { name: "domains", type: "string[]", required: true, description: "Array of entries (min 1). For target_type 'domain': bare domains (subdomains matched automatically). For 'email': full email addresses." },
+                    { name: "match_mode", type: "string", required: true, description: "Required for target_type 'domain': 'credential' (email only), 'url' (URL only), or 'both'. Ignored for 'email' (always credential)." },
                     { name: "webhook_ids", type: "number[]", required: false, description: "Array of webhook IDs to link to this monitor" },
                   ]} />
                 </div>
                 <div>
                   <h4 className="font-semibold mb-3 text-foreground">Example Request</h4>
-                  <CodeBlock code={`curl -X POST "${baseUrl}/api/v1/monitoring/monitors" \\
+                  <CodeBlock code={`# Domain monitor
+curl -X POST "${baseUrl}/api/v1/monitoring/monitors" \\
   -H "X-API-Key: bv_admin_api_key" \\
   -H "Content-Type: application/json" \\
-  -d '{"name": "Banking Domains", "domains": ["bank.co.id", "bca.co.id"], "match_mode": "both", "webhook_ids": [1, 2]}'`} />
+  -d '{"name": "Banking Domains", "domains": ["bank.co.id", "bca.co.id"], "match_mode": "both", "webhook_ids": [1, 2]}'
+
+# Email monitor (exact address match)
+curl -X POST "${baseUrl}/api/v1/monitoring/monitors" \\
+  -H "X-API-Key: bv_admin_api_key" \\
+  -H "Content-Type: application/json" \\
+  -d '{"name": "Execs", "target_type": "email", "domains": ["ceo@bank.co.id"], "webhook_ids": [1]}'`} />
                 </div>
                 <div>
                   <h4 className="font-semibold mb-3 text-foreground flex items-center gap-2">
@@ -1197,8 +1206,9 @@ export default function DocsPage() {
                   <h4 className="font-semibold mb-3 text-foreground">PUT Request Body Parameters</h4>
                   <ParameterTable params={[
                     { name: "name", type: "string", required: false, description: "Monitor display name" },
-                    { name: "domains", type: "string[]", required: false, description: "Array of domains (min 1 if provided)" },
-                    { name: "match_mode", type: "string", required: false, description: "'credential', 'url', or 'both'" },
+                    { name: "target_type", type: "string", required: false, description: "'domain' or 'email'. Switching to 'email' forces match_mode to 'credential'." },
+                    { name: "domains", type: "string[]", required: false, description: "Array of domains or emails (min 1 if provided), validated against the effective target_type" },
+                    { name: "match_mode", type: "string", required: false, description: "'credential', 'url', or 'both' (applies to domain monitors only)" },
                     { name: "is_active", type: "boolean", required: false, description: "Enable or disable the monitor" },
                     { name: "webhook_ids", type: "number[]", required: false, description: "Replace all linked webhooks" },
                   ]} />

--- a/app/monitoring/page.tsx
+++ b/app/monitoring/page.tsx
@@ -17,7 +17,7 @@ import { Alert, AlertDescription } from "@/components/ui/alert"
 import {
   Radio, Webhook, Bell, Plus, Trash2, RefreshCw, Eye,
   CheckCircle2, XCircle, AlertCircle, Globe, Send, Pencil,
-  Activity, Shield
+  Activity, Shield, Mail
 } from "lucide-react"
 import { useToast } from "@/hooks/use-toast"
 
@@ -27,6 +27,7 @@ interface DomainMonitor {
   id: number
   name: string
   domains: string[]
+  target_type: "domain" | "email"
   match_mode: "credential" | "url" | "both"
   is_active: boolean
   webhook_count?: number
@@ -93,6 +94,7 @@ export default function MonitoringPage() {
   const [monitorForm, setMonitorForm] = useState({
     name: "",
     domains: "",
+    target_type: "domain" as "domain" | "email",
     match_mode: "both" as "credential" | "url" | "both",
     webhook_ids: [] as number[],
   })
@@ -205,7 +207,7 @@ export default function MonitoringPage() {
 
   const openCreateMonitorDialog = () => {
     setEditingMonitor(null)
-    setMonitorForm({ name: "", domains: "", match_mode: "both", webhook_ids: [] })
+    setMonitorForm({ name: "", domains: "", target_type: "domain", match_mode: "both", webhook_ids: [] })
     setShowMonitorDialog(true)
   }
 
@@ -220,6 +222,7 @@ export default function MonitoringPage() {
         setMonitorForm({
           name: m.name,
           domains: m.domains.join("\n"),
+          target_type: m.target_type === "email" ? "email" : "domain",
           match_mode: m.match_mode,
           webhook_ids: m.webhooks?.map((w: MonitorWebhookItem) => w.id) || [],
         })
@@ -231,6 +234,7 @@ export default function MonitoringPage() {
   }
 
   const handleSaveMonitor = async () => {
+    const isEmail = monitorForm.target_type === "email"
     const domains = monitorForm.domains
       .split(/[\n,]/)
       .map(d => d.trim())
@@ -241,15 +245,25 @@ export default function MonitoringPage() {
       return
     }
     if (domains.length === 0) {
-      toast({ variant: "destructive", title: "Error", description: "At least one domain is required" })
+      toast({ variant: "destructive", title: "Error", description: isEmail ? "At least one email address is required" : "At least one domain is required" })
       return
+    }
+    // Client-side guard mirroring the API: email monitors need full addresses
+    if (isEmail) {
+      const bad = domains.find(d => !d.includes("@") || d.startsWith("@") || d.endsWith("@"))
+      if (bad) {
+        toast({ variant: "destructive", title: "Error", description: `"${bad}" is not a valid email address` })
+        return
+      }
     }
 
     try {
       const body = {
         name: monitorForm.name.trim(),
         domains,
-        match_mode: monitorForm.match_mode,
+        target_type: monitorForm.target_type,
+        // match_mode is ignored server-side for email monitors
+        match_mode: isEmail ? "credential" : monitorForm.match_mode,
         webhook_ids: monitorForm.webhook_ids,
       }
 
@@ -621,9 +635,17 @@ export default function MonitoringPage() {
                         <Badge variant={monitor.is_active ? "default" : "secondary"}>
                           {monitor.is_active ? "Active" : "Inactive"}
                         </Badge>
-                        <Badge variant="outline">
-                          {monitor.match_mode === "both" ? "Email + URL" : monitor.match_mode === "credential" ? "Email Only" : "URL Only"}
-                        </Badge>
+                        {monitor.target_type === "email" ? (
+                          <Badge variant="outline" className="gap-1">
+                            <Mail className="h-3 w-3" />
+                            Email
+                          </Badge>
+                        ) : (
+                          <Badge variant="outline" className="gap-1">
+                            <Globe className="h-3 w-3" />
+                            {monitor.match_mode === "both" ? "Domain · Email + URL" : monitor.match_mode === "credential" ? "Domain · Email" : "Domain · URL"}
+                          </Badge>
+                        )}
                       </div>
                       {userIsAdmin && (
                         <div className="flex items-center gap-2">
@@ -645,7 +667,7 @@ export default function MonitoringPage() {
                     <div className="flex flex-wrap gap-2 mb-3">
                       {monitor.domains.map((domain, i) => (
                         <Badge key={i} variant="outline" className="gap-1">
-                          <Globe className="h-3 w-3" />
+                          {monitor.target_type === "email" ? <Mail className="h-3 w-3" /> : <Globe className="h-3 w-3" />}
                           {domain}
                         </Badge>
                       ))}
@@ -939,38 +961,69 @@ export default function MonitoringPage() {
             </div>
 
             <div>
-              <Label htmlFor="monitor-domains">Domains (one per line or comma-separated)</Label>
-              <Textarea
-                id="monitor-domains"
-                value={monitorForm.domains}
-                onChange={e => setMonitorForm(f => ({ ...f, domains: e.target.value }))}
-                placeholder={"example.com\nbank.co.id\nmail.example.org"}
-                rows={4}
-              />
-              <p className="text-xs text-muted-foreground mt-1">
-                Subdomains are matched automatically (e.g. &quot;example.com&quot; also matches &quot;sub.example.com&quot;)
-              </p>
-            </div>
-
-            <div>
-              <Label>Match Mode</Label>
+              <Label>Monitor Type</Label>
               <Select
-                value={monitorForm.match_mode}
-                onValueChange={v => setMonitorForm(f => ({ ...f, match_mode: v as "credential" | "url" | "both" }))}
+                value={monitorForm.target_type}
+                onValueChange={v => setMonitorForm(f => ({ ...f, target_type: v as "domain" | "email" }))}
               >
                 <SelectTrigger>
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
-                  <SelectItem value="both">Both (Email + URL)</SelectItem>
-                  <SelectItem value="credential">Email/Credential Only</SelectItem>
-                  <SelectItem value="url">URL Only</SelectItem>
+                  <SelectItem value="domain">Domain</SelectItem>
+                  <SelectItem value="email">Email Address</SelectItem>
                 </SelectContent>
               </Select>
               <p className="text-xs text-muted-foreground mt-1">
-                &quot;Email&quot; matches credentials where login email uses the domain. &quot;URL&quot; matches credentials where the URL targets the domain.
+                {monitorForm.target_type === "email"
+                  ? "Matches credentials whose login is exactly one of the addresses below."
+                  : "Matches credentials by domain (subdomains included)."}
               </p>
             </div>
+
+            <div>
+              <Label htmlFor="monitor-domains">
+                {monitorForm.target_type === "email"
+                  ? "Email Addresses (one per line or comma-separated)"
+                  : "Domains (one per line or comma-separated)"}
+              </Label>
+              <Textarea
+                id="monitor-domains"
+                value={monitorForm.domains}
+                onChange={e => setMonitorForm(f => ({ ...f, domains: e.target.value }))}
+                placeholder={monitorForm.target_type === "email"
+                  ? "ceo@bank.co.id\nadmin@example.com"
+                  : "example.com\nbank.co.id\nmail.example.org"}
+                rows={4}
+              />
+              <p className="text-xs text-muted-foreground mt-1">
+                {monitorForm.target_type === "email"
+                  ? "Exact match only — alerts fire when a leaked credential's login is exactly this address."
+                  : "Subdomains are matched automatically (e.g. \"example.com\" also matches \"sub.example.com\")"}
+              </p>
+            </div>
+
+            {monitorForm.target_type === "domain" && (
+              <div>
+                <Label>Match Mode</Label>
+                <Select
+                  value={monitorForm.match_mode}
+                  onValueChange={v => setMonitorForm(f => ({ ...f, match_mode: v as "credential" | "url" | "both" }))}
+                >
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="both">Both (Email + URL)</SelectItem>
+                    <SelectItem value="credential">Email/Credential Only</SelectItem>
+                    <SelectItem value="url">URL Only</SelectItem>
+                  </SelectContent>
+                </Select>
+                <p className="text-xs text-muted-foreground mt-1">
+                  &quot;Email&quot; matches credentials where login email uses the domain. &quot;URL&quot; matches credentials where the URL targets the domain.
+                </p>
+              </div>
+            )}
 
             <div>
               <Label>Linked Webhooks</Label>

--- a/lib/domain-monitor.ts
+++ b/lib/domain-monitor.ts
@@ -33,8 +33,9 @@ async function mutate(sql: string, params: any[] = []): Promise<any> {
 export interface DomainMonitor {
   id: number
   name: string
-  domains: string[]     // Parsed from JSON
-  match_mode: 'credential' | 'url' | 'both'
+  domains: string[]     // Parsed from JSON. For target_type 'email' these are full email addresses.
+  target_type: 'domain' | 'email'  // 'domain' = match by domain/subdomain, 'email' = exact email match
+  match_mode: 'credential' | 'url' | 'both'  // Ignored when target_type is 'email' (always credential)
   is_active: boolean
   created_by: number | null
   last_triggered_at: string | null
@@ -113,20 +114,57 @@ export interface WebhookPayload {
 }
 
 // ===========================================
+// VALIDATION
+// ===========================================
+
+/**
+ * Validate monitor entries against the target type.
+ * - email: every entry must be a full email address (contain a non-edge '@').
+ * - domain: on create, reject entries containing '@' (a likely mis-entered email).
+ *   On update the domain '@' check is skipped to stay backward compatible with
+ *   any legacy rows that may already contain '@'.
+ * `entries` should already be trimmed/lowercased. Returns an error message, or null if valid.
+ */
+export function validateMonitorEntries(
+  targetType: 'domain' | 'email',
+  entries: string[],
+  isCreate: boolean
+): string | null {
+  if (targetType === 'email') {
+    const bad = entries.find(e => {
+      const at = e.indexOf('@')
+      return at <= 0 || at === e.length - 1 || at !== e.lastIndexOf('@')
+    })
+    if (bad) return `Invalid email address "${bad}". Email monitors require full addresses like "user@example.com".`
+    return null
+  }
+  if (isCreate) {
+    const bad = entries.find(e => e.includes('@'))
+    if (bad) return `"${bad}" looks like an email address. Set target_type to "email" to monitor a specific address, or enter a bare domain.`
+  }
+  return null
+}
+
+// ===========================================
 // MONITOR CRUD
 // ===========================================
 
 export async function createMonitor(data: {
   name: string
   domains: string[]
+  target_type?: 'domain' | 'email'
   match_mode: 'credential' | 'url' | 'both'
   webhook_ids: number[]
   created_by?: number
 }): Promise<number> {
+  const targetType = data.target_type === 'email' ? 'email' : 'domain'
+  // Email monitors always match on credential email; match_mode is irrelevant.
+  const matchMode = targetType === 'email' ? 'credential' : data.match_mode
+
   const result = await mutate(
-    `INSERT INTO domain_monitors (name, domains, match_mode, created_by)
-     VALUES (?, ?, ?, ?)`,
-    [data.name, JSON.stringify(data.domains), data.match_mode, data.created_by || null]
+    `INSERT INTO domain_monitors (name, domains, target_type, match_mode, created_by)
+     VALUES (?, ?, ?, ?, ?)`,
+    [data.name, JSON.stringify(data.domains), targetType, matchMode, data.created_by || null]
   ) as any
 
   const monitorId = result.insertId
@@ -150,6 +188,7 @@ export async function createMonitor(data: {
 export async function updateMonitor(id: number, data: {
   name?: string
   domains?: string[]
+  target_type?: 'domain' | 'email'
   match_mode?: 'credential' | 'url' | 'both'
   is_active?: boolean
   webhook_ids?: number[]
@@ -164,6 +203,15 @@ export async function updateMonitor(id: number, data: {
   if (data.domains !== undefined) {
     updates.push('domains = ?')
     params.push(JSON.stringify(data.domains))
+  }
+  if (data.target_type !== undefined) {
+    const targetType = data.target_type === 'email' ? 'email' : 'domain'
+    updates.push('target_type = ?')
+    params.push(targetType)
+    // Switching to email forces credential matching, regardless of any match_mode sent.
+    if (targetType === 'email') {
+      data = { ...data, match_mode: 'credential' }
+    }
   }
   if (data.match_mode !== undefined) {
     updates.push('match_mode = ?')
@@ -505,13 +553,19 @@ export async function checkMonitorsForDevice(
 
     // Collect all unique domains across all monitors
     const allDomains = new Set<string>()
-    const needsCredentialMatch = new Set<string>()
-    const needsUrlMatch = new Set<string>()
-    
+    const needsCredentialMatch = new Set<string>()  // domain-type: match by email domain/subdomain
+    const needsUrlMatch = new Set<string>()          // domain-type: match by URL domain/subdomain
+    const needsEmailMatch = new Set<string>()        // email-type: exact full-email match
+
     for (const monitor of monitors) {
+      const isEmail = monitor.target_type === 'email'
       for (const domain of monitor.domains) {
         const d = domain.toLowerCase()
         allDomains.add(d)
+        if (isEmail) {
+          needsEmailMatch.add(d)
+          continue
+        }
         if (monitor.match_mode === 'credential' || monitor.match_mode === 'both') {
           needsCredentialMatch.add(d)
         }
@@ -533,8 +587,9 @@ export async function checkMonitorsForDevice(
     const deviceInfo = (sysInfoRows as any[]).length > 0 ? (sysInfoRows as any[])[0] : {}
     const deviceName = (deviceRows as any[]).length > 0 ? (deviceRows as any[])[0].device_name : deviceId
 
-    // 1) Credential match: single query fetching all credentials with email-like usernames
-    if (needsCredentialMatch.size > 0) {
+    // 1) Credential match: single query fetching all credentials with email-like usernames.
+    //    Covers both domain-type (email domain match) and email-type (exact email match) monitors.
+    if (needsCredentialMatch.size > 0 || needsEmailMatch.size > 0) {
       const credRows = await query(
         `SELECT url, username, password, browser, created_at FROM credentials WHERE device_id = ? AND username IS NOT NULL AND username != ''`,
         [deviceId]
@@ -545,21 +600,33 @@ export async function checkMonitorsForDevice(
         const username = (row.username || '').toLowerCase()
         const atIdx = username.lastIndexOf('@')
         if (atIdx === -1) continue
-        
+
         const emailDomain = username.substring(atIdx + 1)
-        
+        const buildMatch = () => ({
+          found_at: row.created_at ? new Date(row.created_at).toISOString() : new Date().toISOString(),
+          url: row.url || '',
+          login: row.username || '',
+          password: row.password || '',
+          browser: row.browser || '',
+        })
+
+        // Domain-type: match by email domain or subdomain
         for (const domain of needsCredentialMatch) {
           if (emailDomain === domain || emailDomain.endsWith('.' + domain)) {
             if (!credentialMatchesByDomain.has(domain)) {
               credentialMatchesByDomain.set(domain, [])
             }
-            credentialMatchesByDomain.get(domain)!.push({
-              found_at: row.created_at ? new Date(row.created_at).toISOString() : new Date().toISOString(),
-              url: row.url || '',
-              login: row.username || '',
-              password: row.password || '',
-              browser: row.browser || '',
-            })
+            credentialMatchesByDomain.get(domain)!.push(buildMatch())
+          }
+        }
+
+        // Email-type: exact full-email match (keyed by the email string)
+        for (const email of needsEmailMatch) {
+          if (username === email) {
+            if (!credentialMatchesByDomain.has(email)) {
+              credentialMatchesByDomain.set(email, [])
+            }
+            credentialMatchesByDomain.get(email)!.push(buildMatch())
           }
         }
       }
@@ -602,6 +669,7 @@ export async function checkMonitorsForDevice(
     // 3) Process each monitor using in-memory results
     for (const monitor of monitors) {
       try {
+        const isEmail = monitor.target_type === 'email'
         const monitorCredentials: CredentialMatch[] = []
         const monitorUrls: CredentialMatch[] = []
         const matchedDomains: string[] = []
@@ -609,10 +677,15 @@ export async function checkMonitorsForDevice(
         for (const domain of monitor.domains) {
           const d = domain.toLowerCase()
           const creds = credentialMatchesByDomain.get(d) || []
-          const urls = urlMatchesByDomain.get(d) || []
-          
+          const urls = isEmail ? [] : (urlMatchesByDomain.get(d) || [])
+
           if (creds.length > 0 || urls.length > 0) {
             matchedDomains.push(d)
+          }
+          if (isEmail) {
+            // Email monitors only ever produce credential matches
+            monitorCredentials.push(...creds)
+            continue
           }
           if (monitor.match_mode === 'credential' || monitor.match_mode === 'both') {
             monitorCredentials.push(...creds)
@@ -753,12 +826,18 @@ export async function checkMonitorsForBatch(
     log(`[MONITOR_PROGRESS] 1/5 Collected ${allMonitoredDomains.size} domains from ${monitors.length} monitors`, 'info')
 
     // Step 3: Collect all unique monitored domains
-    const needsCredentialMatch = new Set<string>()
-    const needsUrlMatch = new Set<string>()
+    const needsCredentialMatch = new Set<string>()  // domain-type: match by email domain/subdomain
+    const needsUrlMatch = new Set<string>()          // domain-type: match by URL domain/subdomain
+    const needsEmailMatch = new Set<string>()        // email-type: exact full-email match
 
     for (const monitor of monitors) {
+      const isEmail = monitor.target_type === 'email'
       for (const domain of monitor.domains) {
         const d = domain.toLowerCase()
+        if (isEmail) {
+          needsEmailMatch.add(d)
+          continue
+        }
         if (monitor.match_mode === 'credential' || monitor.match_mode === 'both') {
           needsCredentialMatch.add(d)
         }
@@ -779,9 +858,10 @@ export async function checkMonitorsForBatch(
     // Credential match: find credentials where email domain matches monitored domains
     const credentialMatchesByDeviceAndDomain = new Map<string, Map<string, CredentialMatch[]>>()
 
-    if (needsCredentialMatch.size > 0) {
+    if (needsCredentialMatch.size > 0 || needsEmailMatch.size > 0) {
       // Build LIKE conditions for email domain matching
       // username LIKE '%@domain.com' OR username LIKE '%@%.domain.com'
+      // Plus exact equality for email-type monitors: username = 'ceo@bank.co.id'
       const likeClauses: string[] = []
       const likeParams: any[] = []
       for (const domain of needsCredentialMatch) {
@@ -789,6 +869,10 @@ export async function checkMonitorsForBatch(
         likeParams.push(`%@${domain}`)
         likeClauses.push('LOWER(c.username) LIKE ?')
         likeParams.push(`%@%.${domain}`)
+      }
+      for (const email of needsEmailMatch) {
+        likeClauses.push('LOWER(c.username) = ?')
+        likeParams.push(email)
       }
 
       const credRows = await query(
@@ -803,29 +887,40 @@ export async function checkMonitorsForBatch(
       log(`🔔 Step 2/3: Credential match query returned ${credRows.length} potential matches`, 'info')
       log(`[MONITOR_PROGRESS] 2/5 Credential match: ${credRows.length} results`, 'info')
 
-      // Group by device_id and match to specific domains in-memory
+      // Group by device_id and match to specific domains/emails in-memory
       for (const row of credRows) {
         const username = (row.username || '').toLowerCase()
         const atIdx = username.lastIndexOf('@')
         if (atIdx === -1) continue
         const emailDomain = username.substring(atIdx + 1)
 
+        const pushMatch = (key: string) => {
+          if (!credentialMatchesByDeviceAndDomain.has(row.device_id)) {
+            credentialMatchesByDeviceAndDomain.set(row.device_id, new Map())
+          }
+          const deviceMap = credentialMatchesByDeviceAndDomain.get(row.device_id)!
+          if (!deviceMap.has(key)) {
+            deviceMap.set(key, [])
+          }
+          deviceMap.get(key)!.push({
+            found_at: row.created_at ? new Date(row.created_at).toISOString() : new Date().toISOString(),
+            url: row.url || '',
+            login: row.username || '',
+            password: row.password || '',
+            browser: row.browser || '',
+          })
+        }
+
+        // Domain-type: match by email domain or subdomain
         for (const domain of needsCredentialMatch) {
           if (emailDomain === domain || emailDomain.endsWith('.' + domain)) {
-            if (!credentialMatchesByDeviceAndDomain.has(row.device_id)) {
-              credentialMatchesByDeviceAndDomain.set(row.device_id, new Map())
-            }
-            const deviceMap = credentialMatchesByDeviceAndDomain.get(row.device_id)!
-            if (!deviceMap.has(domain)) {
-              deviceMap.set(domain, [])
-            }
-            deviceMap.get(domain)!.push({
-              found_at: row.created_at ? new Date(row.created_at).toISOString() : new Date().toISOString(),
-              url: row.url || '',
-              login: row.username || '',
-              password: row.password || '',
-              browser: row.browser || '',
-            })
+            pushMatch(domain)
+          }
+        }
+        // Email-type: exact full-email match (keyed by the email string)
+        for (const email of needsEmailMatch) {
+          if (username === email) {
+            pushMatch(email)
           }
         }
       }
@@ -949,6 +1044,8 @@ export async function checkMonitorsForBatch(
           continue
         }
 
+        const isEmail = monitor.target_type === 'email'
+
         for (const deviceId of matchedDeviceIds) {
           const credMap = credentialMatchesByDeviceAndDomain.get(deviceId) || new Map()
           const urlMap = urlMatchesByDeviceAndDomain.get(deviceId) || new Map()
@@ -960,10 +1057,15 @@ export async function checkMonitorsForBatch(
           for (const domain of monitor.domains) {
             const d = domain.toLowerCase()
             const creds = credMap.get(d) || []
-            const urls = urlMap.get(d) || []
+            const urls = isEmail ? [] : (urlMap.get(d) || [])
 
             if (creds.length > 0 || urls.length > 0) {
               matchedDomains.push(d)
+            }
+            if (isEmail) {
+              // Email monitors only ever produce credential matches
+              monitorCredentials.push(...creds)
+              continue
             }
             if (monitor.match_mode === 'credential' || monitor.match_mode === 'both') {
               monitorCredentials.push(...creds)
@@ -1276,6 +1378,7 @@ function parseMonitorRow(row: any): DomainMonitor {
     id: row.id,
     name: row.name,
     domains,
+    target_type: row.target_type === 'email' ? 'email' : 'domain',
     match_mode: row.match_mode,
     is_active: Boolean(row.is_active),
     created_by: row.created_by,

--- a/lib/mysql.ts
+++ b/lib/mysql.ts
@@ -424,8 +424,9 @@ async function createMonitoringTables() {
       CREATE TABLE IF NOT EXISTS domain_monitors (
         id INT AUTO_INCREMENT PRIMARY KEY,
         name VARCHAR(255) NOT NULL COMMENT 'Monitor display name',
-        domains TEXT NOT NULL COMMENT 'JSON array of domains to monitor',
-        match_mode ENUM('credential', 'url', 'both') NOT NULL DEFAULT 'both' COMMENT 'What to match',
+        domains TEXT NOT NULL COMMENT 'JSON array of domains or exact emails to monitor',
+        target_type ENUM('domain', 'email') NOT NULL DEFAULT 'domain' COMMENT 'domain = match by domain/subdomain, email = exact email match',
+        match_mode ENUM('credential', 'url', 'both') NOT NULL DEFAULT 'both' COMMENT 'What to match (ignored when target_type=email)',
         is_active TINYINT(1) NOT NULL DEFAULT 1,
         created_by INT NULL COMMENT 'User who created this monitor',
         last_triggered_at TIMESTAMP NULL COMMENT 'Last time this monitor was triggered',

--- a/lib/schema-definition.ts
+++ b/lib/schema-definition.ts
@@ -7,7 +7,7 @@
  * Schema Version: 1.0.0
  */
 
-export const SCHEMA_VERSION = "1.5.0"
+export const SCHEMA_VERSION = "1.6.0"
 
 // Column definition type
 export interface ColumnDefinition {
@@ -521,8 +521,9 @@ export const DOMAIN_MONITORS_TABLE: TableDefinition = {
   columns: [
     { name: 'id', type: 'int', nullable: false, extra: 'auto_increment', key: 'PRI' },
     { name: 'name', type: 'varchar(255)', nullable: false, comment: 'Monitor display name' },
-    { name: 'domains', type: 'text', nullable: false, comment: 'JSON array of domains to monitor' },
-    { name: 'match_mode', type: "enum('credential','url','both')", nullable: false, default: "'both'", comment: 'What to match: email domain, URL domain, or both' },
+    { name: 'domains', type: 'text', nullable: false, comment: 'JSON array of domains or exact emails to monitor' },
+    { name: 'target_type', type: "enum('domain','email')", nullable: false, default: "'domain'", comment: 'domain = match by domain/subdomain, email = exact email match' },
+    { name: 'match_mode', type: "enum('credential','url','both')", nullable: false, default: "'both'", comment: 'What to match: email domain, URL domain, or both (ignored when target_type=email)' },
     { name: 'is_active', type: 'tinyint(1)', nullable: false, default: '1' },
     { name: 'created_by', type: 'int', nullable: true, comment: 'User who created this monitor' },
     { name: 'last_triggered_at', type: 'timestamp', nullable: true, comment: 'Last time this monitor was triggered' },

--- a/scripts/init-database.sql
+++ b/scripts/init-database.sql
@@ -380,8 +380,9 @@ CREATE TABLE IF NOT EXISTS import_logs (
 CREATE TABLE IF NOT EXISTS domain_monitors (
     id INT AUTO_INCREMENT PRIMARY KEY,
     name VARCHAR(255) NOT NULL COMMENT 'Monitor display name',
-    domains TEXT NOT NULL COMMENT 'JSON array of domains to monitor',
-    match_mode ENUM('credential', 'url', 'both') NOT NULL DEFAULT 'both' COMMENT 'What to match',
+    domains TEXT NOT NULL COMMENT 'JSON array of domains (target_type=domain) or exact emails (target_type=email) to monitor',
+    target_type ENUM('domain', 'email') NOT NULL DEFAULT 'domain' COMMENT 'domain = match by domain/subdomain, email = exact email match',
+    match_mode ENUM('credential', 'url', 'both') NOT NULL DEFAULT 'both' COMMENT 'What to match (ignored when target_type=email)',
     is_active TINYINT(1) NOT NULL DEFAULT 1,
     created_by INT NULL COMMENT 'User who created this monitor',
     last_triggered_at TIMESTAMP NULL COMMENT 'Last time this monitor was triggered',


### PR DESCRIPTION
Domain monitors gain a `target_type` (domain | email). Domain monitors keep matching by domain/subdomain unchanged; email monitors match a credential's login against exact email addresses.

- schema: add target_type ENUM('domain','email') DEFAULT 'domain' across init-database.sql, lib/mysql.ts runtime init, and schema-definition.ts (db-sync auto-migrates existing DBs); bump SCHEMA_VERSION 1.5.0 -> 1.6.0
- domain-monitor: branch matching in both per-device and batch checks; email type forces credential match; shared validateMonitorEntries()
- API CRUD: support target_type + validation on both v1 (api-key) and app (cookie) monitor create/update endpoints
- UI: monitor type selector, adaptive domains/email field, hide match mode for email, email badge in list
- docs: document target_type and email monitor example

Backward compatible: defaults to 'domain', existing monitors unchanged.